### PR TITLE
Issue 43: taxon prefix not being used. 

### DIFF
--- a/src/omexmeta/Editor.cpp
+++ b/src/omexmeta/Editor.cpp
@@ -391,9 +391,9 @@ namespace omexmeta {
     }
 
     Editor &Editor::addTaxon(const std::string &taxon_id) {
-        Triple triple(uriHandler_, LibrdfNode::fromUriString(getModelUri()).get(),
-                      PredicateFactory("bqbiol", "hasTaxon")->get(),
-                      LibrdfNode::fromUriString("taxonomy:" + taxon_id).get());
+        Triple triple(uriHandler_, LibrdfNode::fromUriString(getModelUri()),
+                      PredicateFactory("bqbiol", "hasTaxon"),
+                      LibrdfNode::fromUriString(Predicate::namespaceMap()["NCBI_Taxon"] + taxon_id));
         model_.addStatement(triple);
         addNamespace(Predicate::namespaceMap()["bqbiol"], "bqbiol");
         addNamespace(Predicate::namespaceMap()["NCBI_Taxon"], "NCBI_Taxon");

--- a/src/omexmeta/include/omexmeta/Triple.h
+++ b/src/omexmeta/include/omexmeta/Triple.h
@@ -35,6 +35,9 @@ namespace omexmeta {
     public:
         using LibrdfStatement::LibrdfStatement;
         using LibrdfStatement::operator=;
+        using LibrdfStatement::setSubject;
+        using LibrdfStatement::setPredicate;
+        using LibrdfStatement::setResource;
 
         /**
          * @brief only a default virtual destructor needed

--- a/src/redland/RedlandWrapper/src/LibrdfNode.cpp
+++ b/src/redland/RedlandWrapper/src/LibrdfNode.cpp
@@ -103,7 +103,6 @@ namespace redland {
         }
 
         else if (std::regex_search(uri_string, m, taxon_regex)) {
-            std::cout << "Taxon regex matched" << std::endl;
             uri_string_ = identifier_dot_org + uri_string;
         }
 

--- a/tests/cpp/omexmeta/EditorTests.cpp
+++ b/tests/cpp/omexmeta/EditorTests.cpp
@@ -827,11 +827,52 @@ TEST_F(EditorTests, TestaddTaxon) {
                            "@prefix bqbiol: <http://biomodels.net/biology-qualifiers/> .\n"
                            "@prefix NCBI_Taxon: <https://identifiers.org/taxonomy:> .\n"
                            "@prefix OMEXlib: <http://omex-library.org/> .\n"
-                           "@prefix myOMEX: <http://omex-library.org/NewOmex.omex/> .\n"
                            "@prefix local: <http://omex-library.org/NewOmex.omex/NewModel.rdf#> .\n"
                            "\n"
-                           "myOMEX:NewModel.xml\n"
+                           "<http://omex-library.org/NewOmex.omex/NewModel.xml>\n"
                            "    bqbiol:hasTaxon NCBI_Taxon:9696 .";
     std::cout << rdf.toString() << std::endl;
+
     ASSERT_TRUE(RDF::equals(&rdf, expected));
+}
+
+
+TEST_F(EditorTests, prefixTest1) {
+    LibrdfNode subject = LibrdfNode::fromUriString("http://omex-library.org/NewOmex.omex/NewModel.xml#model0000");
+    LibrdfNode predicate = LibrdfNode::fromUriString("http://biomodels.net/biology-qualifiers/hasTaxon");
+    LibrdfNode resource = LibrdfNode::fromUriString("https://prefix.org#AnID");
+
+    RDF rdf;
+    Editor editor = rdf.toEditor(SBMLFactory::getSBML(SBML_NOT_ANNOTATED2), true, false);
+
+    SingularAnnotation singularAnnotation = editor.newSingularAnnotation();
+    singularAnnotation.setSubject(subject.getWithoutIncrement());
+
+    singularAnnotation.setPredicate(predicate.getWithoutIncrement());
+    singularAnnotation.setResource(resource.getWithoutIncrement());
+
+    editor.addSingleAnnotation(singularAnnotation);
+    editor.addNamespace("https://prefix.org#", "APrefix");
+
+    std::cout << rdf.toString("turtle") << std::endl;
+}
+
+TEST_F(EditorTests, prefixTest2) {
+    LibrdfNode subject = LibrdfNode::fromUriString("http://omex-library.org/NewOmex.omex/NewModel.xml#model0000");
+    LibrdfNode predicate = LibrdfNode::fromUriString("http://biomodels.net/biology-qualifiers/hasTaxon");
+    LibrdfNode resource = LibrdfNode::fromUriString("https://identifiers.org/taxonomy:9696");
+
+    RDF rdf;
+    Editor editor = rdf.toEditor(SBMLFactory::getSBML(SBML_NOT_ANNOTATED2), true, false);
+
+    SingularAnnotation singularAnnotation = editor.newSingularAnnotation();
+    singularAnnotation.setSubject(subject.getWithoutIncrement());
+
+    singularAnnotation.setPredicate(predicate.getWithoutIncrement());
+    singularAnnotation.setResource(resource.getWithoutIncrement());
+
+    editor.addSingleAnnotation(singularAnnotation);
+    editor.addNamespace("https://identifiers.org/taxonomy:", "NCBI_Taxon");
+
+    std::cout << rdf.toString("turtle") << std::endl;
 }


### PR DESCRIPTION
begin looking into why NCBI_Taxon prefix does not get used when serializing to turtle. I've discovered that if the bit after a prefix begins with a number, then the prefix does not get used. I've updated the relevant github issue asking for advice from the annotation gang